### PR TITLE
Added functionality to upload file and save that file to the client directory

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -28,7 +28,7 @@ function App() {
 
     <Grid container direction="column" spacing={15} alignItems="center">
       <Grid item>
-        <ButtonAppBar></ButtonAppBar>      
+        <ButtonAppBar></ButtonAppBar>    
       </Grid>
 
       <Grid item>

--- a/client/src/components/UploadButton.js
+++ b/client/src/components/UploadButton.js
@@ -2,8 +2,8 @@ import * as React from 'react';
 
 const UploadButton = () => {
     return (
-        <form >
-            <input id="contained-button-file" type="file" accept="application/pdf" />
+        <form action="/upload" method="post" enctype="multipart/form-data">
+            <input type="file" name="file" accept="application/pdf" />
             <input type="submit" />
         </form>
     );

--- a/server/app.py
+++ b/server/app.py
@@ -1,10 +1,19 @@
-from flask import Flask
+from flask import Flask, request
+from werkzeug.utils import secure_filename
 
 app = Flask(__name__)
 
 @app.route('/members')
 def index():
     return {"members": ["Mem 1", "Mem 2", "Mem 3"]}
+
+@app.route('/upload', methods = ['GET', 'POST'])
+def upload_file():
+    if request.method == 'POST':
+        f = request.files['file']
+        if f.filename != '':
+            f.save(secure_filename(f.filename))
+        return 'file uploaded successfully'
 
 if __name__ == '__main__':
     app.run(debug=True)


### PR DESCRIPTION
In the front end, I added an action to the form. When you upload the file and press Submit, the route `/upload` will be called in the back end (you can see this in `app.py`.

I added an upload function to `app.py` that currently processes the file by saving it to the client directory.

The next pull request will process the file properly.